### PR TITLE
Use absolute path for custom output path

### DIFF
--- a/main.go
+++ b/main.go
@@ -91,7 +91,11 @@ func main() {
 	}
 
 	if *outPath != "" {
-		*outPath = filepath.Clean(*outPath)
+		*outPath, err = filepath.Abs(*outPath)
+
+		if err != nil {
+			log.Fatalf("Failed to determine absolute output path: %s", err.Error())
+		}
 
 		certPath := filepath.Join(*outPath, *commonName+".crt")
 		keyPath := filepath.Join(*outPath, *commonName+".key")


### PR DESCRIPTION
Call `Abs(path)` instead of just `Clean(path)`.

This doesn't affect where anything is written, but it does have the desirable side-effect of displaying the complete output path to the user. This looks nicer, especially when one passes something like `-out .` for the current working directory.